### PR TITLE
Let DataManagers store commit history of variables; implement read()

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,6 +190,10 @@ class TransactionManager():
         # instructions waiting because of lock conflict (write, regular read) or site failure (RO read)
         self.instructionBuffer = []
         self.dataManagers = [DataManager(i, self.time) for i in range(1, 11)]
+
+        # { dataManagerIdx: [('fail', time1), ('recover', time2)] }
+        self.dataManagerStatusHistory = defaultdict(list)
+
         # self.conflictGraph = dict() # Dict[Transaction, List[Transaction], key - being waited, value - waiting
     
 
@@ -281,7 +285,17 @@ class TransactionManager():
         assert(transactionName in self.transactions)
         T = self.transactions[transactionName]
         # TODO: update new variable value to dataManager
-        print(T.variableFinalValues)
+        for variable, value in T.variableFinalValues.items():
+            variableIdx = int(variable[1:])
+            dataManagerIndices = []
+            for i in range(1, 11):
+                if variableIdx % 2 == 0:
+                    dataManagerIndices.append(i - 1)
+                elif i == (1 + (variableIdx % 10)): # odd variable index
+                    dataManagerIndices.append(i - 1)
+            print(variable, dataManagerIndices)
+            # self.dataManagerStatusHistory
+
         self.lockTable.releaseLock(T)
         del self.transactions[transactionName]
 

--- a/main.py
+++ b/main.py
@@ -24,8 +24,6 @@ class Transaction():
         self.locks = dict()
         self.variableFinalValues = dict()
 
-        self.dataManagers = [DataManager(i) for i in range(1, 11)]
-
 
 class DataManager():
     def __init__(self, dataManagerId: int):
@@ -188,7 +186,9 @@ class TransactionManager():
         self.time = 0
         self.transactions = dict() # Dict[str, Transaction]
         self.lockTable = LockTable()
+        # instructions waiting because of lock conflict (write, regular read) or site failure (RO read)
         self.instructionBuffer = []
+        self.dataManagers = [DataManager(i) for i in range(1, 11)]
         # self.conflictGraph = dict() # Dict[Transaction, List[Transaction], key - being waited, value - waiting
     
 
@@ -263,12 +263,15 @@ class TransactionManager():
         pass
 
     def end(self, transactionName: str):
+        # TODO: release locks held by the transaction
+        #   scan instructionBuffer to see if any waiting instructions can now be run (if yes, they should be RO reads)
         pass
 
     def fail(self, site: int):
         pass
     
     def recover(self, site: int):
+        # TODO: scan instructionBuffer to see if any waiting instructions can now be run (if yes, they should be RO reads)
         pass
 
 
@@ -349,18 +352,18 @@ def test_dead_lock():
     LT.getWriteLock(T2, "x1")
     assert(LT.checkDeadLock() == (True, T2))
 
-test_exclusive_lock()
-test_shared_and_exclusive_lock()
-test_release_lock()
-test_starvation()
-test_repeated_lock()
-test_dead_lock()
+# test_exclusive_lock()
+# test_shared_and_exclusive_lock()
+# test_release_lock()
+# test_starvation()
+# test_repeated_lock()
+# test_dead_lock()
 
-# TM = TransactionManager()
-# for line in stdin:
-#     line = line.strip()
-#     if line == "" or line.startswith("//"):
-#         continue
-#     TM.runInstruction(line)
-#     TM.tick()
+TM = TransactionManager()
+for line in stdin:
+    line = line.strip()
+    if line == "" or line.startswith("//"):
+        continue
+    TM.runInstruction(line)
+    TM.tick()
 

--- a/tests/test0.txt
+++ b/tests/test0.txt
@@ -5,5 +5,8 @@ begin(T1)
 W(T1,x1,101)
   // another testcomment
 R(T1,x1)
+W(T1,x2,202)
+  // another testcomment
+R(T1,x2)
 end(T1)
 dump()

--- a/tests/test0.txt
+++ b/tests/test0.txt
@@ -4,9 +4,11 @@
 begin(T1)
 W(T1,x1,101)
   // another testcomment
-R(T1,x1)
 W(T1,x2,202)
-  // another testcomment
-R(T1,x2)
 end(T1)
+
+begin(T2)
+R(T2,x1)
+R(T2,x2)
+end(T2)
 dump()

--- a/tests/test1.txt
+++ b/tests/test1.txt
@@ -1,3 +1,6 @@
+// Test 1.
+// T2 should abort, T1 should not, because of kill youngest
+
 begin(T1)
 begin(T2)
 W(T1,x1,101)

--- a/tests/test2.txt
+++ b/tests/test2.txt
@@ -1,0 +1,13 @@
+// Test 2
+// No aborts happens, since read-only transactions use
+// multiversion read protocol.
+
+begin(T1)
+beginRO(T2)
+W(T1,x1,101) 
+R(T2,x2)
+W(T1,x2,102) 
+R(T2,x1)
+end(T1) 
+end(T2)
+dump()

--- a/tests/test7.txt
+++ b/tests/test7.txt
@@ -1,0 +1,12 @@
+// Test 7
+// T2 should read the initial version of x3 based on multiversion read
+// consistency.
+
+begin(T1)
+beginRO(T2)
+R(T2,x1)
+R(T2,x2)
+W(T1,x3,33)
+end(T1)
+R(T2,x3)
+end(T2)

--- a/tests/test8.txt
+++ b/tests/test8.txt
@@ -1,3 +1,7 @@
+// Test 8
+// T2 still reads the initial value of x3
+// T3 still reads the value of x3 written by T1
+
 begin(T1)
 beginRO(T2)
 R(T2,x1)


### PR DESCRIPTION
- Update the code of DataManagers to store the entire commit history of variables, not just the most recently committed variable value. This is needed for both regular reads and RO reads.
- Implement read(). Transaction abort logic for RO reads has not been completed yet.

Testing: test0, test2, test7, test8